### PR TITLE
CSP: Allow connect-src *

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -27,9 +27,9 @@ http {
     more_set_headers "Strict-Transport-Security: max-age=31104000";
 
     # CSP
-    more_set_headers "Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src 'self' validator.spaceapi.io\"";
-    more_set_headers "X-Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src 'self' validator.spaceapi.io\"";
-    more_set_headers "X-WebKit-CSP: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src 'self' validator.spaceapi.io\"";
+    more_set_headers "Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
+    more_set_headers "X-Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
+    more_set_headers "X-WebKit-CSP: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
 
     server {
         listen 80;


### PR DESCRIPTION
I didn't realize that we fetch URLs directly... Thus we need `*`.

This can be reverted once the validator accepts URLs directly and fetches them on the server.

@gidsi if you agree, merge it directly, until then the validator is broken.