### PR TITLE
Fix nginx config

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -27,9 +27,9 @@ http {
     more_set_headers "Strict-Transport-Security: max-age=31104000";
 
     # CSP
-    more_set_headers "Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
-    more_set_headers "X-Content-Security-Policy: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
-    more_set_headers "X-WebKit-CSP: \"default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *\"";
+    more_set_headers "Content-Security-Policy: default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *";
+    more_set_headers "X-Content-Security-Policy: default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *";
+    more_set_headers "X-WebKit-CSP: default-src 'self'; object-src 'none'; frame-src 'none'; connect-src *";
 
     server {
         listen 80;


### PR DESCRIPTION
The escaping lead to '"' being present in the header itself, which is
invalid.