### PR TITLE
Fix display of required values in docs

### DIFF
--- a/content/docs/contents.lr
+++ b/content/docs/contents.lr
@@ -16,6 +16,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>api</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -28,6 +29,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>space</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -38,6 +40,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>logo</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -48,6 +51,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -79,6 +83,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>lat</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -89,6 +94,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>lon</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -102,7 +108,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>spacefed</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -113,6 +118,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>spacenet</h3><span class="type">(boolean)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -123,6 +129,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>spacesaml</h3><span class="type">(boolean)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -133,6 +140,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>spacephone</h3><span class="type">(boolean)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -214,6 +222,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>open</h3><span class="type">(boolean)</span>
+<span class="tag required">required</span>
 <span class="tag nullable">nullable</span>
 </header>
 <details class="togglable">
@@ -255,7 +264,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>icon</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -266,6 +274,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>open</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -276,6 +285,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>closed</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -302,6 +312,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>name</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -312,6 +323,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>type</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -322,6 +334,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>timestamp</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -345,6 +358,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>contact</h3><span class="type">(object)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -556,6 +570,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>issue_report_channels</h3><span class="type">(array of string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -592,6 +607,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -602,6 +618,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -614,6 +631,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -657,6 +675,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(boolean)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -667,6 +686,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -710,6 +730,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -720,6 +741,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -732,6 +754,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -785,6 +808,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -795,6 +819,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -870,6 +895,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -880,6 +906,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -955,6 +982,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -965,6 +993,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1040,6 +1069,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1050,6 +1080,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1128,6 +1159,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1138,6 +1170,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1150,6 +1183,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1193,6 +1227,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1203,6 +1238,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1258,6 +1294,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1268,6 +1305,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1280,6 +1318,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1345,6 +1384,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1355,6 +1395,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1381,6 +1422,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1391,6 +1433,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1417,6 +1460,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1427,6 +1471,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1453,6 +1498,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1463,6 +1509,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1481,6 +1528,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>location</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1536,6 +1584,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1566,6 +1615,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>mac</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1622,6 +1672,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1632,6 +1683,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>unit</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1687,6 +1739,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1740,6 +1793,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>value</h3><span class="type">(number)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1810,7 +1864,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>blog</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1831,6 +1884,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1844,7 +1898,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>wiki</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1865,6 +1918,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1878,7 +1932,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>calendar</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1899,6 +1952,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1912,7 +1966,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>flickr</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1933,6 +1986,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1949,7 +2003,6 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>cache</h3><span class="type">(object)</span>
-<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1960,6 +2013,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>schedule</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -1997,6 +2051,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>name</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -2007,6 +2062,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>url</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -2017,6 +2073,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>type</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -2029,6 +2086,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>start</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>
@@ -2039,6 +2097,7 @@ but they may be left away if they're not required.
 <li><section class="item">
 <header>
 <h3>end</h3><span class="type">(string)</span>
+<span class="tag required">required</span>
 </header>
 <details class="togglable">
 <summary>Details</summary>


### PR DESCRIPTION
Since we upgraded the JSON schema format for the schema files, the old
logic did not work anymore (the required flag was moved to the parent
object).

![sapi](https://user-images.githubusercontent.com/105168/64102641-a765ab00-cd70-11e9-8592-72436f76f58a.png)

Fixes #55.