### PR TITLE
Removes unused stylesheet

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,7 +6,6 @@
 
     <link rel="stylesheet" href="{{ '/static/gen/style.css' | asseturl }}">
     <script type=text/javascript src="{{ '/static/gen/app.js'| asseturl }}" charset="utf-8"></script>
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ get_pygments_stylesheet()|url }}">
 
     <title>{% block title %}Welcome{% endblock %} — SpaceAPI</title>


### PR DESCRIPTION
I've tried to figur out where we use fontawesome, i couldn't find it. I think we added it for the footer logos but switched over to svg there a while ago.