### PR TITLE
Webpack be gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install dependencies:
 
 Run dev server:
 
-    lektor server -f webpack -f scsscompile
+    lektor server -f scsscompile
 
 Now open `http://localhost:5000/` in your browser.
 

--- a/SpaceAPI.lektorproject
+++ b/SpaceAPI.lektorproject
@@ -9,4 +9,4 @@ lektor-webpack-support = 0.5
 lektor-markdown-header-anchors = 0.3.1
 lektor-markdown-highlighter = 0.3.1
 lektor-jinja-content = 0.4.3
-lektor-scsscompile = 1.2.4
+lektor-scsscompile = 1.3.0

--- a/SpaceAPI.lektorproject
+++ b/SpaceAPI.lektorproject
@@ -5,7 +5,6 @@ url = https://spaceapi.io
 url_style = absolute
 
 [packages]
-lektor-webpack-support = 0.5
 lektor-markdown-header-anchors = 0.3.1
 lektor-markdown-highlighter = 0.3.1
 lektor-jinja-content = 0.4.3


### PR DESCRIPTION
Remove webpack plugin. It started throwing weird error messages and wasn't maintained since 2018. Since we don't actually use it anymore, remove it.