### PR TITLE
Fix pushing just latest docker tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Push Docker image
         run: |
           docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" && \
-          docker push spaceapi/website
+          docker push -a spaceapi/website


### PR DESCRIPTION
We update the website in a few month since we're using the v3 tag but just the latest tag was pushed. This should fix it