### PR TITLE
Split CI and publish runs into separate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
-  schedule:
-    - cron: '30 3 * * 2'
 
 name: CI
 
@@ -17,26 +14,3 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Docker image
         run: docker build --no-cache .
-
-  publish:
-    name: Publish Docker image
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v2
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-      - name: Build Docker image
-        run: |
-          docker build \
-            --no-cache \
-            -t spaceapi/website:latest \
-            -t spaceapi/website:v3 \
-            -t spaceapi/website:${{ steps.extract_branch.outputs.branch }} \
-            .
-      - name: Push Docker image
-        run: |
-          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" && \
-          docker push -a spaceapi/website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [master]
   pull_request:
+    branches: [master]
   schedule:
     - cron: '30 3 * * 2'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 on:
-  push:
-    branches: [master]
   pull_request:
 
 name: CI
@@ -9,7 +7,6 @@ jobs:
   test:
     name: Build website
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '30 3 * * 2'
+
+name: Publish
+
+jobs:
+  publish:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Build Docker image
+        run: |
+          docker build \
+            --no-cache \
+            -t spaceapi/website:latest \
+            -t spaceapi/website:v3 \
+            -t spaceapi/website:${{ steps.extract_branch.outputs.branch }} \
+            .
+      - name: Push Docker image
+        run: |
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}" && \
+          docker push -a spaceapi/website

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,20 +10,15 @@ jobs:
   publish:
     name: Publish Docker image
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
       - name: Build Docker image
         run: |
           docker build \
             --no-cache \
             -t spaceapi/website:latest \
             -t spaceapi/website:v3 \
-            -t spaceapi/website:${{ steps.extract_branch.outputs.branch }} \
+            -t spaceapi/website:master \
             .
       - name: Push Docker image
         run: |


### PR DESCRIPTION
The workflow got completely stopped, since it contains scheduled triggers and there was no activity on the repository for months. By splitting that, we avoid the CI workflow from breaking.