### PR TITLE
Docs generator improvements

### DIFF
--- a/asset_sources/scss/_apidocs.scss
+++ b/asset_sources/scss/_apidocs.scss
@@ -87,4 +87,21 @@
         margin-top: 8px;
         padding-left: 8px;
     }
+
+    dl {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        column-gap: 4px;
+        row-gap: 8px;
+        margin: 8px 0;
+
+        dt {
+            grid-column: 1;
+            font-weight: bold;
+        }
+
+        dd {
+            grid-column: 2;
+        }
+    }
 }

--- a/content/docs/contents.lr
+++ b/content/docs/contents.lr
@@ -35,11 +35,12 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The versions your SpaceAPI endpoint supports</p>
-<h4>Nested array items</h4>
-<span>string</span>
-<h4>Required item values</h4>
-<p>The array must contain the value
-<code>14</code>.</p>
+<dl>
+<dt>Nested array items:</dt>
+<dd>string</dd>
+<dt>Required item values:</dt>
+<dd><p>The array must contain the value <code>14</code>.</dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -126,10 +127,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The timezone the space is located in. It should be formatted according to the <a target="_blank" href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">TZ database location names</a>.</p>
-<h4>Examples</h4>
-<p>
-<samp>Europe/Kyiv</samp>, <samp>Antarctica/Palmer</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Europe/Kyiv</samp>, <samp>Antarctica/Palmer</samp></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -178,10 +179,14 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>URL(s) of webcams in your space</p>
-<h4>Minimum number of items</h4>
-<p>1</p>
-<h4>Nested array items</h4>
-<span>string</span>
+<dl>
+<dt>Minimum number of items:</dt>
+<dd>1</dd>
+</dl>
+<dl>
+<dt>Nested array items:</dt>
+<dd>string</dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -348,10 +353,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Phone number, including country code with a leading plus sign</p>
-<h4>Examples</h4>
-<p>
-<samp>+1 800 555 4567</samp>, <samp>+41 79 123 45 67</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>+1 800 555 4567</samp>, <samp>+41 79 123 45 67</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -362,10 +367,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>URI for Voice-over-IP via SIP</p>
-<h4>Examples</h4>
-<p>
-<samp>sip:yourspace@sip.example.org</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>sip:yourspace@sip.example.org</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -376,8 +381,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Persons who carry a key and are able to open the space upon request. One of the fields irc_nick, phone, email or twitter must be specified.</p>
-<h4>Minimum number of items</h4>
-<p>1</p>
+<dl>
+<dt>Minimum number of items:</dt>
+<dd>1</dd>
+</dl>
 <h4>Nested array items</h4>
 <ul class="group">
 <li><section class="item">
@@ -408,10 +415,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Phone number, including country code with a leading plus sign</p>
-<h4>Examples</h4>
-<p>
-<samp>+1 800 555 4567</samp>, <samp>+41 79 123 45 67</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>+1 800 555 4567</samp>, <samp>+41 79 123 45 67</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -432,10 +439,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Twitter username with leading <code>@</code></p>
-<h4>Examples</h4>
-<p>
-<samp>@space_api</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>@space_api</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -456,10 +463,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Mastodon username</p>
-<h4>Examples</h4>
-<p>
-<samp>@ordnung@chaos.social</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>@ordnung@chaos.social</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -470,10 +477,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Matrix username (including domain)</p>
-<h4>Examples</h4>
-<p>
-<samp>@user:example.org</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>@user:example.org</samp></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -487,10 +494,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>URL of the IRC channel</p>
-<h4>Examples</h4>
-<p>
-<samp>irc://example.org/#channelname</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>irc://example.org/#channelname</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -501,10 +508,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Twitter username with leading <code>@</code></p>
-<h4>Examples</h4>
-<p>
-<samp>@space_api</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>@space_api</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -515,10 +522,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Mastodon username</p>
-<h4>Examples</h4>
-<p>
-<samp>@ordnung@chaos.social</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>@ordnung@chaos.social</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -599,10 +606,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>A URL to find information about the Space in the Gopherspace</p>
-<h4>Examples</h4>
-<p>
-<samp>gopher://gopher.binary-kitchen.de</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>gopher://gopher.binary-kitchen.de</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -613,10 +620,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Matrix channel/community for the Hackerspace</p>
-<h4>Examples</h4>
-<p>
-<samp>#spaceroom:example.org</samp>, <samp>+spacecommunity:example.org</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>#spaceroom:example.org</samp>, <samp>+spacecommunity:example.org</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -627,10 +634,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>URL to a Mumble server/channel, as specified in https://wiki.mumble.info/wiki/Mumble_URL</p>
-<h4>Examples</h4>
-<p>
-<samp>mumble://mumble.example.org/spaceroom?version=1.2.0</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>mumble://mumble.example.org/spaceroom?version=1.2.0</samp></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -676,8 +683,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value</p>
-<h4>Valid values</h4>
-<p><code>°C</code> | <code>°F</code> | <code>K</code> | <code>°De</code> | <code>°N</code> | <code>°R</code> | <code>°Ré</code> | <code>°Rø</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>°C</code> | <code>°F</code> | <code>K</code> | <code>°De</code> | <code>°N</code> | <code>°R</code> | <code>°Ré</code> | <code>°Rø</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -689,10 +698,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Inside</samp>, <samp>Ceiling</samp>, <samp>Room 1</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Inside</samp>, <samp>Ceiling</samp>, <samp>Room 1</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -748,10 +757,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Front door</samp>, <samp>Chill room</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Front door</samp>, <samp>Chill room</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -807,8 +816,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of pressure used by your sensor<br>Note: The <code>hPA</code> unit is deprecated and should not be used anymore. Use the correct <code>hPa</code> unit instead.</p>
-<h4>Valid values</h4>
-<p><code>hPa</code> | <code>hPA</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>hPa</code> | <code>hPA</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -820,10 +831,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Inside</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Inside</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -889,8 +900,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Choose the appropriate unit for your radiation sensor instance</p>
-<h4>Valid values</h4>
-<p><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -921,10 +934,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -980,8 +993,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Choose the appropriate unit for your radiation sensor instance</p>
-<h4>Valid values</h4>
-<p><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1012,10 +1027,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1071,8 +1086,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Choose the appropriate unit for your radiation sensor instance</p>
-<h4>Valid values</h4>
-<p><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1103,10 +1120,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1162,8 +1179,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Choose the appropriate unit for your radiation sensor instance</p>
-<h4>Valid values</h4>
-<p><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>cpm</code> | <code>r/h</code> | <code>µSv/h</code> | <code>mSv/a</code> | <code>µSv/a</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1194,10 +1213,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1256,8 +1275,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>%</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>%</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1269,10 +1290,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Outside</samp>, <samp>Roof</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1328,8 +1349,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit, either <samp>btl</samp> for bottles or <samp>crt</samp> for crates</p>
-<h4>Valid values</h4>
-<p><code>btl</code> | <code>crt</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>btl</code> | <code>crt</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1340,10 +1363,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Entrance</samp>, <samp>Room 1</samp>, <samp>Fridge 3</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Entrance</samp>, <samp>Room 1</samp>, <samp>Fridge 3</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1399,8 +1422,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>mW</code> | <code>W</code> | <code>VA</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>mW</code> | <code>W</code> | <code>VA</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1412,10 +1437,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Room 1</samp>, <samp>Lab</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Room 1</samp>, <samp>Lab</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1493,8 +1518,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>m/s</code> | <code>km/h</code> | <code>kn</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>m/s</code> | <code>km/h</code> | <code>kn</code></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -1531,8 +1558,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>m/s</code> | <code>km/h</code> | <code>kn</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>m/s</code> | <code>km/h</code> | <code>kn</code></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -1569,8 +1598,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>°</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>°</code></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -1607,8 +1638,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.</p>
-<h4>Valid values</h4>
-<p><code>m</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>m</code></dd>
+</dl>
 </div></details>
 </section></li>
 </ul>
@@ -1626,10 +1659,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Roof</samp>, <samp>Entrance</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Roof</samp>, <samp>Entrance</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1673,8 +1706,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>This field is optional but you can use it to the network type such as <samp>wifi</samp> or <samp>cable</samp>. You can even expose the number of <a href="https://spacefed.net/wiki/index.php/Spacenet" target="_blank">spacenet</a>-authenticated connections.</p>
-<h4>Valid values</h4>
-<p><code>wifi</code> | <code>cable</code> | <code>spacenet</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>wifi</code> | <code>cable</code> | <code>spacenet</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1730,10 +1765,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The location of your sensor</p>
-<h4>Examples</h4>
-<p>
-<samp>Lab</samp>, <samp>Room 1</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Lab</samp>, <samp>Room 1</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1927,10 +1962,14 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>List of hackerspace members that are currently occupying the space.</p>
-<h4>Minimum number of items</h4>
-<p>1</p>
-<h4>Nested array items</h4>
-<span>string</span>
+<dl>
+<dt>Minimum number of items:</dt>
+<dd>1</dd>
+</dl>
+<dl>
+<dt>Nested array items:</dt>
+<dd>string</dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -1954,8 +1993,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The current network traffic, in bits/second or packets/second (or both)</p>
-<h4>Minimum number of items</h4>
-<p>1</p>
+<dl>
+<dt>Minimum number of items:</dt>
+<dd>1</dd>
+</dl>
 <h4>Nested array items</h4>
 <ul class="group">
 <li><section class="item">
@@ -2093,10 +2134,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Type of the feed</p>
-<h4>Examples</h4>
-<p>
-<samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2131,10 +2172,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Type of the feed</p>
-<h4>Examples</h4>
-<p>
-<samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2169,10 +2210,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Type of the feed</p>
-<h4>Examples</h4>
-<p>
-<samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2207,10 +2248,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Type of the feed</p>
-<h4>Examples</h4>
-<p>
-<samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>rss</samp>, <samp>atom</samp>, <samp>ical</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2238,8 +2279,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>Your project sites (links to GitHub, wikis or wherever your projects are hosted)</p>
-<h4>Nested array items</h4>
-<span>string</span>
+<dl>
+<dt>Nested array items:</dt>
+<dd>string</dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2306,10 +2349,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>The name of the membership plan</p>
-<h4>Examples</h4>
-<p>
-<samp>Student Membership</samp>, <samp>Normal Membership</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>Student Membership</samp>, <samp>Normal Membership</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2332,10 +2375,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>What's the currency? It should be formatted according to <a href="https://en.wikipedia.org/wiki/ISO_4217" target="_blank">ISO 4217</a> short-code format.</p>
-<h4>Examples</h4>
-<p>
-<samp>EUR</samp>, <samp>USD</samp>, <samp>CHF</samp>
-</p>
+<dl>
+<dt>Examples:</dt>
+<dd><samp>EUR</samp>, <samp>USD</samp>, <samp>CHF</samp></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">
@@ -2347,8 +2390,10 @@ You can use the [SpaceAPI validator](/validator/) to verify that you implement t
 <summary>Details</summary>
 <div>
 <p>How often is the membership billed? If you select other, please specify in the description what your billing interval is.</p>
-<h4>Valid values</h4>
-<p><code>yearly</code> | <code>monthly</code> | <code>weekly</code> | <code>daily</code> | <code>hourly</code> | <code>other</code></p>
+<dl>
+<dt>Valid values:</dt>
+<dd><code>yearly</code> | <code>monthly</code> | <code>weekly</code> | <code>daily</code> | <code>hourly</code> | <code>other</code></dd>
+</dl>
 </div></details>
 </section></li>
 <li><section class="item">

--- a/generate_schema_docs.py
+++ b/generate_schema_docs.py
@@ -7,6 +7,14 @@ from typing import List
 from slugify import slugify
 
 
+def print_definition_list(attributes: collections.OrderedDict):
+    print('<dl>')
+    for k, v in attributes.items():
+        print(f'<dt>{k}:</dt>')
+        print(f'<dd>{v}</dd>')
+    print('</dl>')
+
+
 def visit_generic(path: str, name: str, data, nullable: bool, required: bool):
     slug = slugify('schema-key-' + path)
     print(f'<header id="{slug}">')
@@ -39,6 +47,11 @@ def visit_generic(path: str, name: str, data, nullable: bool, required: bool):
 
 def visit_object(path: str, name, data):
     assert 'properties' in data
+    attributes = collections.OrderedDict()
+    if 'minProperties' in data:
+        attributes['Minimum number of properties'] = data['minProperties']
+    if len(attributes) > 0:
+        print_definition_list(attributes)
     print('<h4>Nested object properties</h4>')
     print('<ul class="group">')
     visit(path, data['properties'], data.get('required', []))

--- a/generate_schema_docs.py
+++ b/generate_schema_docs.py
@@ -8,6 +8,14 @@ from slugify import slugify
 
 
 def print_definition_list(attributes: collections.OrderedDict):
+    """
+    Print a definition list for the specified attributes.
+
+    If the attributes are empty, nothing will be printed.
+
+    """
+    if len(attributes) == 0:
+        return
     print('<dl>')
     for k, v in attributes.items():
         print(f'<dt>{k}:</dt>')
@@ -32,26 +40,25 @@ def visit_generic(path: str, name: str, data, nullable: bool, required: bool):
     print('<div>')
     if 'description' in data:
         print(f'<p>{data["description"]}</p>')
+
+    attributes = collections.OrderedDict()
     if 'enum' in data:
-        print('<h4>Valid values</h4>')
-        print(f'<p><code>{"</code> | <code>".join(data["enum"])}</code></p>')
-    if 'examples' in data:
-        print('<h4>Examples</h4>')
-        print('<p>')
-        print(', '.join(f'<samp>{e}</samp>' for e in data['examples']))
-        print('</p>')
+        attributes['Valid values'] = f'<code>{"</code> | <code>".join(data["enum"])}</code>'
     if 'minItems' in data:
-        print('<h4>Minimum number of items</h4>')
-        print(f'<p>{data["minItems"]}</p>')
+        attributes['Minimum number of items'] = data['minItems']
+    if 'examples' in data:
+        attributes['Examples'] = ', '.join(f'<samp>{e}</samp>' for e in data['examples'])
+    print_definition_list(attributes)
 
 
 def visit_object(path: str, name, data):
     assert 'properties' in data
+
     attributes = collections.OrderedDict()
     if 'minProperties' in data:
         attributes['Minimum number of properties'] = data['minProperties']
-    if len(attributes) > 0:
-        print_definition_list(attributes)
+    print_definition_list(attributes)
+
     print('<h4>Nested object properties</h4>')
     print('<ul class="group">')
     visit(path, data['properties'], data.get('required', []))
@@ -61,25 +68,27 @@ def visit_object(path: str, name, data):
 def visit_array(path: str, name, data):
     assert 'items' in data
     items = data['items']
-    print('<h4>Nested array items</h4>')
-    if items['type'] == 'string':
-        print('<span>string</span>')
-        if 'enum' in items:
-            print('<h5>Valid values</h5>')
-            print('<p><code>%s</code></p>' % '</code> | <code>'.join(items['enum']))
-    elif items['type'] == 'object':
+
+    attributes = collections.OrderedDict()
+
+    if items['type'] == 'object':
+        print('<h4>Nested array items</h4>')
         print('<ul class="group">')
         visit(path, items['properties'], items.get('required', []))
         print('</ul>')
+    else:
+        attributes['Nested array items'] = items['type']
+
     if 'contains' in data:
-        print('<h4>Required item values</h4>')
         # Ensure that we can handle this schema logic
         keys = set(data['contains'].keys())
         if keys != {'const'}:
             raise ValueError('Unspported "contains" variant(s): {}'.format(keys - {'const'}))
         # Generate docs
-        print('<p>The array must contain the value')
-        print('<code>{}</code>.</p>'.format(data['contains']['const']))
+        attributes['Required item values'] = \
+            f'<p>The array must contain the value <code>{data["contains"]["const"]}</code>.'
+
+    print_definition_list(attributes)
 
 
 def visit_string(path: str, name, data):


### PR DESCRIPTION
- Add support for `minProperties`
- Add support for `dependentRequired`
- Introduce attributes system that uses definition lists in the generated HTML

This will be a requirement for schema 15 docs if https://github.com/SpaceApi/schema/pull/115 is merged.

Refs #137.