### PR TITLE
Drop Twitter link from footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,9 +4,6 @@
       <div class="leftcontainer">
         <img src="{{ '/static/images/spaceapi-logo-230px.png' | url }}" class="logo" alt="SpaceAPI">
         <div id="reficons">
-          <a href="https://twitter.com/space_api">
-            <img src="{{ '/static/images/twitter.svg' | url }}" alt="Twitter">
-          </a>
           <a href="https://github.com/SpaceApi">
             <img src="{{ '/static/images/github.svg' | url }}" alt="Github">
           </a>


### PR DESCRIPTION
Twitter has become a cesspool of trolls and intolerance. The space_api account also shows no posts.

So I would propose to drop it. The demographic of Hackerspaces is more active on Mastodon/Fedi anyway.

If someone still has the password to this account, consider deleting the account as well :grimacing: 